### PR TITLE
Adds user story 12

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -1,0 +1,19 @@
+class Admin::ApplicationsController < ApplicationController
+
+  def show
+    @applications = Application.all
+    @pending_applications = Application.all.where(applications: {app_status: 1})
+    @app = Application.find(params[:id])
+  end
+  
+  def update
+    @app = Application.find(params[:id])
+    @app.update(app_status: 2)
+    redirect_to "/admin/applications/#{@app.id}"
+  end
+
+  private
+  def admin_app_params
+    params.permit(:app_status)
+  end
+end

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -1,0 +1,17 @@
+
+<%if @app.app_status == "Pending" %>
+<p>Application for: </p><%=@app.name%>
+<p>Pet(s): </p><%@app.pets.each do |pet|%>
+  <%=pet.name%>
+  <p><%= button_to "Approve Application", "/admin/applications/#{@app.id}", method: :patch, local: true %></p>
+<%end%>
+<%end%>
+
+
+<%if @app.app_status == "Accepted" %>
+<p>Application for: </p><%=@app.name%>
+<p>Pet(s): </p><%@app.pets.each do |pet|%>
+<%=pet.name%>
+  <p> You've been approved</p>
+<%end%>
+<%end%>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -45,4 +45,7 @@ Rails.application.routes.draw do
   patch "/applications/:id", to: 'applications#update'
 
   get '/admin/shelters', to: 'admin/shelters#index'
+
+  get 'admin/applications/:id', to: 'admin/applications#show'
+  patch 'admin/applications/:id', to: 'admin/applications#update'
 end

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe 'visiting admin app show page' do
+  let!(:shelter_1) {Shelter.create!(name: "Dumb Friends League", foster_program: true, city: "Denver", rank: "1") }
+  
+  let!(:pet) { Pet.create!(shelter_id: shelter_1.id, adoptable: true, age: 6, breed: "Soft Coated Wheaton Terrier", name: "Larry") }
+  
+  let!(:application_1) { Application.create!(name: "Andra", street_address: "2305 W. Lake St.", city: "Fort Collins", state: "Colorado", zip_code: 80525, app_status: "Pending", pets_on_app: pet.name) }
+  let!(:application_2) { Application.create!(name: "Holly", street_address: "2307 W. Lake St.", city: "Fort Collins", state: "Colorado", zip_code: 80525, app_status: "In Progress", pets_on_app: pet.name) }
+
+  let!(:application_pet) { ApplicationPet.create!(pet_id: pet.id, application_id: application_1.id) }
+
+
+  describe 'For every pet that the application is for, I see a button to approve the application for that specific pet' do
+    describe 'when I click that button' do
+      it "taken back to the admin app show page, next to pet that I approved, no button and isntead indicator they've been approved" do
+        visit "/admin/applications/#{application_1.id}"
+
+        expect(page).to have_button("Approve Application")
+        
+        click_on "Approve Application"
+
+        expect(current_path).to eq("/admin/applications/#{application_1.id}")
+        expect(page).to_not have_button("Approve Application")
+        expect(page).to have_content("#{pet.name}")
+        expect(page).to have_content("You've been approved")
+      end
+    end
+  end
+end


### PR DESCRIPTION
12. Approving a Pet for Adoption

As a visitor
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to approve the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I approved, I do not see a button to approve this pet
And instead I see an indicator next to the pet that they have been approved