### PR TITLE
Added corrected user story 12

### DIFF
--- a/app/controllers/admin/applications_controller.rb
+++ b/app/controllers/admin/applications_controller.rb
@@ -1,19 +1,14 @@
 class Admin::ApplicationsController < ApplicationController
 
   def show
-    @applications = Application.all
-    @pending_applications = Application.all.where(applications: {app_status: 1})
     @app = Application.find(params[:id])
   end
   
   def update
     @app = Application.find(params[:id])
-    @app.update(app_status: 2)
-    redirect_to "/admin/applications/#{@app.id}"
-  end
+    pet_application = ApplicationPet.find_application_pet(params[:pet_id], params[:id])
+    pet_application.update(pet_status: params[:pet_status].to_i)
 
-  private
-  def admin_app_params
-    params.permit(:app_status)
+    redirect_to "/admin/applications/#{@app.id}"
   end
 end

--- a/app/models/application_pet.rb
+++ b/app/models/application_pet.rb
@@ -1,4 +1,10 @@
 class ApplicationPet < ApplicationRecord
   belongs_to :application
   belongs_to :pet
+
+  enum pet_status:["Pending", "Accepted", "Rejected"]
+
+  def self.find_application_pet(pet_id, app_id)
+    where(application_id: app_id, pet_id: pet_id).first
+  end
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -14,6 +14,12 @@ class Pet < ApplicationRecord
     where(adoptable: true)
   end
 
+  def approved?(app_id)
+    status = application_pets.where(application_id: app_id).pluck(:pet_status).first
+    status == "Accepted"
+  end 
+
+
   # def self.search(pet_name)
   #   if pet_name 
   #     pet = Pet.find_by(name: pet_name)

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -1,17 +1,19 @@
+<h1><%= @app.name %></h1>
 
-<%if @app.app_status == "Pending" %>
-<p>Application for: </p><%=@app.name%>
-<p>Pet(s): </p><%@app.pets.each do |pet|%>
-  <%=pet.name%>
-  <p><%= button_to "Approve Application", "/admin/applications/#{@app.id}", method: :patch, local: true %></p>
-<%end%>
-<%end%>
+<h4>Full Address: </h4>
+  <p><%= @app.street_address %></p>
+  <p><%= @app.city %>, 
+  <%= @app.state %> 
+  <%= @app.zip_code %></p>
+<br> 
 
+<h4>Requested Pets: </h4>
 
-<%if @app.app_status == "Accepted" %>
-<p>Application for: </p><%=@app.name%>
-<p>Pet(s): </p><%@app.pets.each do |pet|%>
-<%=pet.name%>
-  <p> You've been approved</p>
-<%end%>
-<%end%>
+<% @app.pets.each do |pet| %>
+<%= pet.name %>
+  <%if pet.approved?(@app.id) %>
+    <p> Pet has been approved</p>
+  <% else %>
+    <p><%= button_to "Approve #{pet.name}", "/admin/applications/#{@app.id}?pet_id=#{pet.id}", method: :patch, local: true, params: {pet_status: 1} %></p>
+  <% end %>
+<% end %>

--- a/db/migrate/20230210220600_create_application_pets.rb
+++ b/db/migrate/20230210220600_create_application_pets.rb
@@ -1,6 +1,7 @@
 class CreateApplicationPets < ActiveRecord::Migration[5.2]
   def change
     create_table :application_pets do |t|
+      t.integer :pet_status, default: 0
       t.references :pet, foreign_key: true
       t.references :application, foreign_key: true
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,6 +16,7 @@ ActiveRecord::Schema.define(version: 2023_02_10_220600) do
   enable_extension "plpgsql"
 
   create_table "application_pets", force: :cascade do |t|
+    t.integer "pet_status", default: 0
     t.bigint "pet_id"
     t.bigint "application_id"
     t.index ["application_id"], name: "index_application_pets_on_application_id"

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -3,12 +3,14 @@ require 'rails_helper'
 RSpec.describe 'visiting admin app show page' do
   let!(:shelter_1) {Shelter.create!(name: "Dumb Friends League", foster_program: true, city: "Denver", rank: "1") }
   
-  let!(:pet) { Pet.create!(shelter_id: shelter_1.id, adoptable: true, age: 6, breed: "Soft Coated Wheaton Terrier", name: "Larry") }
+  let!(:pet_1) { Pet.create!(shelter_id: shelter_1.id, adoptable: true, age: 6, breed: "Soft Coated Wheaton Terrier", name: "Larry") }
+  let!(:pet_2) { Pet.create!(shelter_id: shelter_1.id, adoptable: true, age: 1, breed: "Boston Terrier", name: "Fred") }
   
-  let!(:application_1) { Application.create!(name: "Andra", street_address: "2305 W. Lake St.", city: "Fort Collins", state: "Colorado", zip_code: 80525, app_status: "Pending", pets_on_app: pet.name) }
-  let!(:application_2) { Application.create!(name: "Holly", street_address: "2307 W. Lake St.", city: "Fort Collins", state: "Colorado", zip_code: 80525, app_status: "In Progress", pets_on_app: pet.name) }
+  let!(:application_1) { Application.create!(name: "Andra", street_address: "2305 W. Lake St.", city: "Fort Collins", state: "Colorado", zip_code: 80525, app_status: "Pending", pets_on_app: [pet_1.name, pet_2.name]) }
+  let!(:application_2) { Application.create!(name: "Holly", street_address: "2307 W. Lake St.", city: "Fort Collins", state: "Colorado", zip_code: 80525, app_status: "In Progress", pets_on_app: pet_1.name) }
 
-  let!(:application_pet) { ApplicationPet.create!(pet_id: pet.id, application_id: application_1.id) }
+  let!(:application_pet) { ApplicationPet.create!(pet_id: pet_1.id, application_id: application_1.id) }
+  let!(:application_pet_2) { ApplicationPet.create!(pet_id: pet_2.id, application_id: application_1.id) }
 
 
   describe 'For every pet that the application is for, I see a button to approve the application for that specific pet' do
@@ -16,14 +18,19 @@ RSpec.describe 'visiting admin app show page' do
       it "taken back to the admin app show page, next to pet that I approved, no button and isntead indicator they've been approved" do
         visit "/admin/applications/#{application_1.id}"
 
-        expect(page).to have_button("Approve Application")
+        expect(page).to have_button("Approve #{pet_1.name}")
+        expect(page).to have_button("Approve #{pet_2.name}")
         
-        click_on "Approve Application"
+        click_on "Approve #{pet_1.name}"
 
         expect(current_path).to eq("/admin/applications/#{application_1.id}")
-        expect(page).to_not have_button("Approve Application")
-        expect(page).to have_content("#{pet.name}")
-        expect(page).to have_content("You've been approved")
+        expect(page).to_not have_button("Approve #{pet_1.name}")
+        expect(page).to have_button("Approve #{pet_2.name}")
+
+        expect(page).to have_content("#{pet_1.name}")
+        expect(page).to have_content("#{pet_2.name}")
+
+        expect(page).to have_content("Pet has been approved")
       end
     end
   end

--- a/spec/models/application_pet_spec.rb
+++ b/spec/models/application_pet_spec.rb
@@ -1,8 +1,26 @@
 require 'rails_helper'
 
 RSpec.describe ApplicationPet, type: :model do
+  let!(:shelter_1) {Shelter.create!(name: "Dumb Friends League", foster_program: true, city: "Denver", rank: "1") }
+
+  let!(:pet_1) { Pet.create!(shelter_id: shelter_1.id, adoptable: true, age: 6, breed: "Soft Coated Wheaton Terrier", name: "Larry") }
+  let!(:pet_2) { Pet.create!(shelter_id: shelter_1.id, adoptable: true, age: 1, breed: "Boston Terrier", name: "Fred") }
+
+  let!(:application_1) { Application.create!(name: "Andra", street_address: "2305 W. Lake St.", city: "Fort Collins", state: "Colorado", zip_code: 80525, app_status: "Pending", pets_on_app: [pet_1.name, pet_2.name]) }
+  let!(:application_2) { Application.create!(name: "Holly", street_address: "2307 W. Lake St.", city: "Fort Collins", state: "Colorado", zip_code: 80525, app_status: "In Progress", pets_on_app: pet_1.name) }
+
+  let!(:application_pet) { ApplicationPet.create!(pet_id: pet_1.id, application_id: application_1.id) }
+  let!(:application_pet_2) { ApplicationPet.create!(pet_id: pet_2.id, application_id: application_1.id) }
+  
   describe "relationships" do
-    it {should belong_to :application}
-    it {should belong_to :pet}
+    it { should belong_to :application }
+    it { should belong_to :pet }
+    it { should define_enum_for(:pet_status).with_values(["Pending", "Accepted", "Rejected"])}
+  end
+
+  describe 'class methods' do
+    it '::find_application_pet' do 
+      expect(ApplicationPet.find_application_pet(pet_1.id, application_1.id)).to eq(application_pet)
+    end
   end
 end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -41,5 +41,23 @@ RSpec.describe Pet, type: :model do
         expect(@pet_3.shelter_name).to eq(@shelter_1.name)
       end
     end
+
+    describe "#approved?" do
+      it 'should return false if application_pet is pending' do
+        application_1 = Application.create!(name: "Andra", street_address: "2305 W. Lake St.", city: "Fort Collins", state: "Colorado", zip_code: 80525, app_status: "Pending", pets_on_app: [@pet_1.name, @pet_2.name])
+      
+        application_pet = ApplicationPet.create!(pet_id: @pet_1.id, application_id: application_1.id)
+        
+        expect(@pet_1.approved?(application_1.id)).to eq(false)
+      end
+
+      it 'should return true if application_pet is accepted' do
+        application_1 = Application.create!(name: "Andra", street_address: "2305 W. Lake St.", city: "Fort Collins", state: "Colorado", zip_code: 80525, pets_on_app: [@pet_2.name])
+    
+        application_pet = ApplicationPet.create!(pet_id: @pet_2.id, application_id: application_1.id, pet_status: "Accepted")
+      
+        expect(@pet_2.approved?(application_1.id)).to eq(true)
+      end
+    end
   end
 end


### PR DESCRIPTION
12. Approving a Pet for Adoption

As a visitor
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to approve the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I approved, I do not see a button to approve this pet
And instead I see an indicator next to the pet that they have been approved