### PR TITLE
Add User story 13 & 14

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,7 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
-    nokogiri (1.14.1)
+    nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     orderly (0.1.1)

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -19,18 +19,8 @@ class Pet < ApplicationRecord
     status == "Accepted"
   end 
 
-
-  # def self.search(pet_name)
-  #   if pet_name 
-  #     pet = Pet.find_by(name: pet_name)
-  #     if pet 
-  #       self.where(name: pet)
-  #     else
-  #       Pet.all
-  #     end
-  #   else 
-  #     Pet.all
-  #   end
-  #   # where("name ILIKE ", "%#{pet_name}%")
-  # end
+  def rejected?(app_id)
+    status = application_pets.where(application_id: app_id).pluck(:pet_status).first
+    status == "Rejected"
+  end
 end

--- a/app/views/admin/applications/show.html.erb
+++ b/app/views/admin/applications/show.html.erb
@@ -13,7 +13,10 @@
 <%= pet.name %>
   <%if pet.approved?(@app.id) %>
     <p> Pet has been approved</p>
+  <% elsif pet.rejected?(@app.id) %>
+    <p> Pet has been rejected</p>
   <% else %>
     <p><%= button_to "Approve #{pet.name}", "/admin/applications/#{@app.id}?pet_id=#{pet.id}", method: :patch, local: true, params: {pet_status: 1} %></p>
+    <p><%= button_to "Reject #{pet.name}", "/admin/applications/#{@app.id}?pet_id=#{pet.id}", method: :patch, local: true, params: {pet_status: 2} %></p>
   <% end %>
 <% end %>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,15 +15,15 @@ shelter_2 = Shelter.create!(name: "Humane Society", foster_program: false, city:
 shelter_3 = Shelter.create!(name: "Max Fund", foster_program: true, city: "Denver", rank: "3")
 
 pet_1 = Pet.create!(shelter_id: shelter_1.id, adoptable: true, age: 6, breed: "Soft Coated Wheaton Terrier", name: "Larry")
-pet_1 = Pet.create!(shelter_id: shelter_1.id, adoptable: true, age: 1, breed: "Boston Terrier", name: "Max")
-pet_1 = Pet.create!(shelter_id: shelter_1.id, adoptable: false, age: 4, breed: "Soft Coated Wheaton Terrier", name: "Daisy")
+pet_2 = Pet.create!(shelter_id: shelter_1.id, adoptable: true, age: 1, breed: "Boston Terrier", name: "Max")
+pet_3 = Pet.create!(shelter_id: shelter_1.id, adoptable: false, age: 4, breed: "Soft Coated Wheaton Terrier", name: "Daisy")
 
-pet_1 = Pet.create!(shelter_id: shelter_2.id, adoptable: false, age: 4, breed: "Pit Bull", name: "Sally")
-pet_1 = Pet.create!(shelter_id: shelter_2.id, adoptable: false, age: 3, breed: "Poodle", name: "Joey")
-pet_1 = Pet.create!(shelter_id: shelter_2.id, adoptable: true, age: 2, breed: "Golden Retriever", name: "Spot")
+pet_4 = Pet.create!(shelter_id: shelter_2.id, adoptable: false, age: 4, breed: "Pit Bull", name: "Sally")
+pet_5 = Pet.create!(shelter_id: shelter_2.id, adoptable: false, age: 3, breed: "Poodle", name: "Joey")
+pet_6 = Pet.create!(shelter_id: shelter_2.id, adoptable: true, age: 2, breed: "Golden Retriever", name: "Spot")
 
-pet_1 = Pet.create!(shelter_id: shelter_3.id, adoptable: false, age: 4, breed: "Soft Coated Wheaton Terrier", name: "Sal")
-pet_1 = Pet.create!(shelter_id: shelter_3.id, adoptable: true, age: 2, breed: "Golden Doodle", name: "Barbara")
-pet_1 = Pet.create!(shelter_id: shelter_3.id, adoptable: true, age: 1, breed: "French Bull Dog", name: "Gabby")
+pet_7 = Pet.create!(shelter_id: shelter_3.id, adoptable: false, age: 4, breed: "Soft Coated Wheaton Terrier", name: "Sal")
+pet_8 = Pet.create!(shelter_id: shelter_3.id, adoptable: true, age: 2, breed: "Golden Doodle", name: "Barbara")
+pet_9 = Pet.create!(shelter_id: shelter_3.id, adoptable: true, age: 1, breed: "French Bull Dog", name: "Gabby")
 
 application_1 = Application.create!(name: "Andra", street_address: "2305 W. Lake St.", city: "Fort Collins", state: "Colorado", zip_code: 80525, description: "I love them", pets_on_app: "Daisy, Sal", app_status: "Accepted")

--- a/spec/features/admin/applications/show_spec.rb
+++ b/spec/features/admin/applications/show_spec.rb
@@ -34,4 +34,26 @@ RSpec.describe 'visiting admin app show page' do
       end
     end
   end
+
+  describe 'For every pet that the application is for, I see a button to reject the application for that specific pet' do
+    describe 'when I click that button' do
+      it "taken back to the admin app show page, next to pet that I rejected, no button and isntead indicator they've been rejected" do
+        visit "/admin/applications/#{application_1.id}"
+
+        expect(page).to have_button("Reject #{pet_1.name}")
+        expect(page).to have_button("Reject #{pet_2.name}")
+        
+        click_on "Reject #{pet_1.name}"
+
+        expect(current_path).to eq("/admin/applications/#{application_1.id}")
+        expect(page).to_not have_button("Reject #{pet_1.name}")
+        expect(page).to have_button("Reject #{pet_2.name}")
+
+        expect(page).to have_content("#{pet_1.name}")
+        expect(page).to have_content("#{pet_2.name}")
+
+        expect(page).to have_content("Pet has been rejected")
+      end
+    end
+  end
 end

--- a/spec/models/pet_spec.rb
+++ b/spec/models/pet_spec.rb
@@ -59,5 +59,23 @@ RSpec.describe Pet, type: :model do
         expect(@pet_2.approved?(application_1.id)).to eq(true)
       end
     end
+
+    describe "#rejected?" do
+      it 'should return true if application_pet is rejected' do
+        application_1 = Application.create!(name: "Andra", street_address: "2305 W. Lake St.", city: "Fort Collins", state: "Colorado", zip_code: 80525, app_status: "Pending", pets_on_app: [@pet_1.name, @pet_2.name])
+      
+        application_pet = ApplicationPet.create!(pet_id: @pet_1.id, application_id: application_1.id, pet_status: "Rejected")
+        
+        expect(@pet_1.rejected?(application_1.id)).to eq(true)
+      end
+
+      it 'should return false if application_pet is accepted or pending' do
+        application_1 = Application.create!(name: "Andra", street_address: "2305 W. Lake St.", city: "Fort Collins", state: "Colorado", zip_code: 80525, pets_on_app: [@pet_2.name])
+    
+        application_pet = ApplicationPet.create!(pet_id: @pet_2.id, application_id: application_1.id, pet_status: "Accepted")
+      
+        expect(@pet_2.rejected?(application_1.id)).to eq(false)
+      end
+    end
   end
 end


### PR DESCRIPTION
13. Rejecting a Pet for Adoption

As a visitor
When I visit an admin application show page ('/admin/applications/:id')
For every pet that the application is for, I see a button to reject the application for that specific pet
When I click that button
Then I'm taken back to the admin application show page
And next to the pet that I rejected, I do not see a button to approve or reject this pet
And instead I see an indicator next to the pet that they have been rejected

14. Approved/Rejected Pets on one Application do not affect other Applications

As a visitor
When there are two applications in the system for the same pet
When I visit the admin application show page for one of the applications
And I approve or reject the pet for that application
When I visit the other application's admin show page
Then I do not see that the pet has been accepted or rejected for that application
And instead I see buttons to approve or reject the pet for this specific application